### PR TITLE
don't require changes to be committed to build jar

### DIFF
--- a/src/applied_science/deps_library.clj
+++ b/src/applied_science/deps_library.clj
@@ -142,7 +142,8 @@
                       (and (-> options :git/status :git :dirty?)
                            (not (:dry-run options))
                            (not (#{"install"
-                                   "version"} COMMAND)))
+                                   "version"
+                                   "jar"} COMMAND)))
                       "Current repository has uncommitted work. Please commit your changes and retry.")
                 (fail! options))
 


### PR DESCRIPTION
Because sometimes you just want to build a jar file without having to commit your changes.