### PR TITLE
update dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,9 @@
 {:paths ["src"]
- :deps {seancorfield/depstar {:mvn/version "0.5.2"}
-        com.workframe/garamond {:mvn/version "0.4.0"}
-        deps-deploy {:mvn/version "0.0.9"}}
+ :deps {seancorfield/depstar {:mvn/version "2.0.216"}
+        com.workframe/garamond {;:mvn/version "0.4.0"
+                                :git/url "https://github.com/workframers/garamond"
+                                :sha "a5077bc99d5f6e303735505068d5363d3b2cc00c"}
+        deps-deploy/deps-deploy {:mvn/version "0.0.12"}}
  :aliases
  {:release
   {:main-opts ["-m" "applied-science.deps-library"

--- a/src/applied_science/deps_library.clj
+++ b/src/applied_science/deps_library.clj
@@ -8,6 +8,7 @@
             [garamond.version :as v]
             [garamond.util :refer [exit]]
             [hf.depstar.uberjar :as uberjar]
+            [hf.depstar :as depstar]
             [clojure.string :as str]
             [taoensso.timbre :as timbre]))
 
@@ -62,8 +63,7 @@
 (defn jar [{:as options :keys [jar/path jar/type]}]
   (println (str "JAR... " path " (" (name type) ")"))
   (when-not (:dry-run options)
-    (uberjar/uber-main {:dest path :jar type}
-                       (:depstar/uber-main options)))
+    (depstar/jar {:jar path}))
   options)
 
 (defn deploy [{:as options :keys [jar/path]}]


### PR DESCRIPTION
Sean Corfield mentioned that there's a lot of improvements in the latest `depstar` and so I briefly tried to update everything. It seems like things are working with the changes here but haven't done a lot of testing. `workframe/garamond` is missing a release for recent (seemingly breaking?) [changes](https://github.com/workframers/garamond/issues/9) in tools deps.

I appreciate the ambition of this project of just being a one stop shop for versioning and publishing!
